### PR TITLE
Fix: Disabling while in 'serve' mode after first run

### DIFF
--- a/mkdocs_exclude_unused_files/plugin.py
+++ b/mkdocs_exclude_unused_files/plugin.py
@@ -30,6 +30,7 @@ class ExcludeUnusedFilesPluginConfig(mkdocs.config.base.Config):
     folders_to_never_remove_from = mkdocs.config.config_options.Type(list, default=["assets"])
     file_name_suffixes_to_trim = mkdocs.config.config_options.Type(list, default=["#only-light", "#only-dark"])
 
+
 class ExcludeUnusedFilesPlugin(BasePlugin[ExcludeUnusedFilesPluginConfig]):
     asset_files: Set[str] = set()
     file_types_to_check = [

--- a/mkdocs_exclude_unused_files/plugin.py
+++ b/mkdocs_exclude_unused_files/plugin.py
@@ -73,18 +73,17 @@ class ExcludeUnusedFilesPlugin(BasePlugin[ExcludeUnusedFilesPluginConfig]):
 
     @mkdocs.plugins.event_priority(-100)
     def on_startup(self, *, command, dirty) -> None:
-        if not self.config.enabled:
+        self.is_enabled = self.config.enabled
+        if not self.is_enabled:
             log.debug("exclude-unused-files plugin disabled")
             return
         # Disable plugin when the documentation is served, i.e., "mkdocs serve" is used
         if command == "serve" and not self.config.enabled_on_serve:
             log.debug("exclude-unused-files plugin disabled while MkDocs is running in 'serve' mode.")
-            self.disabled_by_serve = True
+            self.is_enabled = False
             return
-        else:
-            self.disabled_by_serve = False
 
-        if self.config.enabled:
+        if self.is_enabled:
             if self.config.file_types_override_mode == "append" and self.config.file_types_to_check != []:
                 log.debug("extending default file_types_to_check: %s", ", ".join(self.config.file_types_to_check))
                 self.file_types_to_check.extend(self.config.file_types_to_check)
@@ -101,7 +100,7 @@ class ExcludeUnusedFilesPlugin(BasePlugin[ExcludeUnusedFilesPluginConfig]):
 
     @mkdocs.plugins.event_priority(-100)
     def on_files(self, files: Files, config: MkDocsConfig) -> Optional[Files]:
-        if not self.config.enabled or self.disabled_by_serve:
+        if not self.is_enabled:
             log.debug("exclude-unused-files plugin disabled")
             return None
 
@@ -127,7 +126,7 @@ class ExcludeUnusedFilesPlugin(BasePlugin[ExcludeUnusedFilesPluginConfig]):
 
     @mkdocs.plugins.event_priority(-100)
     def on_post_page(self, output: str, page: Page, config: MkDocsConfig) -> Optional[str]:
-        if not self.config.enabled or self.disabled_by_serve:
+        if not self.is_enabled:
             log.debug("exclude-unused-files plugin disabled")
             return None
 
@@ -165,7 +164,7 @@ class ExcludeUnusedFilesPlugin(BasePlugin[ExcludeUnusedFilesPluginConfig]):
         return output
 
     def on_post_build(self, config: MkDocsConfig) -> None:
-        if not self.config.enabled or self.disabled_by_serve:
+        if not self.is_enabled:
             log.debug("exclude-unused-files plugin disabled")
             return None
 


### PR DESCRIPTION
This fixes a case where rebuilding the documentation when running in serve mode will ignore the `enabled_on_serve`.

When running exclude-unused-files in conjunction with `mkdocs-material` (9.5.25), I noticed that runs after the first run in `serve` mode were ignoring the `enabled_on_serve` flag. First run would be 1.3s, second would be 5.0 seconds.

After some log debugging, it turns out that `self.config` is actually reset between build runs in `serve` mode. And therefore setting `self.config.enabled = False` was not sticking.

To account for that, I stored an alternative variable `disabled_by_serve` that's tied to the self variable, outside of the config. This way, it should not be reset between runs.

----

Please Note: I've never really programmed in Python before, so debugging this has been a unique experience. :sweat_smile: 